### PR TITLE
when dependency is missing tests may hang

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,10 @@ name=Perinci-CmdLine-Lite
 [@Author::PERLANCAR]
 :version=0.23
 
+[Test::CheckDeps]
+fatal = 1
+;when dependency is missing tests may hang
+
 ;[LocaleTextDomain]
 
 [Prereqs / TestRequires]


### PR DESCRIPTION
check dependencies and call BAIL_OUT if one of them is missing
