### PR TITLE
Match build prereqs to usage

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,9 @@ Test::More=0.98
 Test::Perinci::CmdLine=1.47
 ;!lint_prereqs assume-used "for test suite"
 YAML::Old=0
+Pod::Coverage::TrustPod=0
+Test::Pod=0
+Test::Pod::Coverage=0
 
 [Prereqs]
 perl=5.010001


### PR DESCRIPTION
One of the CPANTS kwalitee issues is to match the list of build
prerequisites in META.yml with those actually used in the distribution.
This change adds the prerequisites found to be missing by the CPANTS
service.

This PR is submitted in the hope that it is helpful.  If you want to have something changed or updated, please just let me know and I'll make the appropriate changes and resubmit the pull request.