### PR TITLE
Add 'provides' info to dist metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -85,3 +85,5 @@ module=JSON
 [Extras / lint-prereqs / assume-provided]
 ; only when Perinci::CmdLine::Base is subclassed by Perinci::CmdLine::Classic
 Moo=0
+
+[MetaProvides::Package]


### PR DESCRIPTION
By adding 'provides' information to the dist addresses the
'meta_yml_has_provides' kwalitee issue on CPANTS but can also help other
tools in the Perl ecosystem to work better or provide more information.

This pull request is submitted in the hope that it is helpful.  If you would like to changed in any way, please just let me know and I'll update and resubmit as necessary.