### PR TITLE
Fix podchecker errors

### DIFF
--- a/lib/Perinci/CmdLine/Base.pm
+++ b/lib/Perinci/CmdLine/Base.pm
@@ -2191,8 +2191,7 @@ subcommands.
 
 =item * C<use_utf8> (bool, optional)
 
-Whether to issue L<< binmode(STDOUT, ":utf8") >>. See L</"LOGGING"> for more
-details.
+Whether to issue C<< binmode(STDOUT, ":utf8") >>. See L<Perinci::CmdLine::Manual/"LOGGING"> for more details.
 
 =item * C<undo> (bool, optional)
 
@@ -2351,8 +2350,8 @@ from command-line options like C<--log-level>, C<--trace>, etc.
 
 =head2 $cmd->run() => ENVRES
 
-The main method to run your application. See L</"PROGRAM FLOW"> for more details
-on what this method does.
+The main method to run your application. See L</"PROGRAM FLOW (NORMAL)"> for
+more details on what this method does.
 
 =head2 $cmd->do_dump() => ENVRES
 


### PR DESCRIPTION
`podchecker` found three issues with the code:

  - the `binmode` text in the docs for `use_utf8` shouldn't have been an
    internal link, hence it was turned into code-formatted text.
  - the `LOGGING` section was removed in the process of splitting this
    dist away from the full `Perinci::CmdLine` dist, hence the internal
    link was no longer correct.  It should have pointed to the `LOGGING`
    section in the manual of the full dist; this issue has been fixed
    here.
  - the internal link to `PROGRAM FLOW` needed to specify which of the
    `PROGRAM FLOW` sections it was to point to; this link was made more
    specific in this change, hence fixing the `podchecker` error.