### PR TITLE
Fix perlcritic warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,7 @@ Fcntl=0
 File::Temp=0
 File::Which=0
 Getopt::Long=0
+IO::Interactive=0
 JSON::MaybeXS=0
 List::Util=1.45
 Log::ger=0.023

--- a/lib/Perinci/CmdLine/Base.pm
+++ b/lib/Perinci/CmdLine/Base.pm
@@ -1335,7 +1335,7 @@ sub select_output_handle {
             last unless $pager; # ENV{PAGER} can be set 0/'' to disable paging
             #log_trace("Paging output using %s", $pager);
             ## no critic (InputOutput::RequireBriefOpen)
-            open $handle, "| $pager";
+            open $handle, "|-", $pager;
         }
         $handle //= \*STDOUT;
     }

--- a/lib/Perinci/CmdLine/Base.pm
+++ b/lib/Perinci/CmdLine/Base.pm
@@ -7,6 +7,7 @@ use 5.010001;
 use strict;
 use warnings;
 use Log::ger;
+use IO::Interactive qw(is_interactive);
 
 # this class can actually be a role instead of base class for pericmd &
 # pericmd-lite, but Mo is more lightweight than Role::Tiny (also R::T doesn't
@@ -177,7 +178,7 @@ our %copts = (
         summary => 'Set output format to json',
         handler => sub {
             my ($go, $val, $r) = @_;
-            $r->{format} = (-t STDOUT) ? 'json-pretty' : 'json';
+            $r->{format} = (is_interactive(*STDOUT)) ? 'json-pretty' : 'json';
         },
         tags => ['category:output'],
     },
@@ -1028,7 +1029,7 @@ sub _parse_argv2 {
                 my $src = $as->{cmdline_src} // '';
 
                 # we only get from stdin if stdin is piped
-                $src = '' if $src eq 'stdin_or_args' && -t STDIN;
+                $src = '' if $src eq 'stdin_or_args' && is_interactive(*STDIN);
 
                 if ($src && $as->{req}) {
                     # don't complain, we will fill argument from other source
@@ -1197,7 +1198,7 @@ sub parse_cmdline_src {
                     my $prompt = Perinci::Object::rimeta($as)->langprop('cmdline_prompt') //
                         sprintf($self->default_prompt_template, $an);
                     print $prompt;
-                    my $iactive = (-t STDOUT);
+                    my $iactive = (is_interactive(*STDOUT));
                     Term::ReadKey::ReadMode('noecho')
                           if $term_readkey_available && $iactive && $as->{is_password};
                     chomp($r->{args}{$an} = <STDIN>);
@@ -1242,7 +1243,7 @@ sub parse_cmdline_src {
                             $is_ary ? [<>] :
                                 do {local $/; ~~<>};
                     $r->{args}{"-cmdline_src_$an"} = $src;
-                } elsif ($src eq 'stdin_or_args' && !(-t STDIN)) {
+                } elsif ($src eq 'stdin_or_args' && !(is_interactive(*STDIN))) {
                     unless (defined($r->{args}{$an})) {
                         $r->{args}{$an} = $do_stream ?
                             __gen_iter(\*STDIN, $as, $an) :
@@ -1499,7 +1500,7 @@ sub run {
     # EXPERIMENTAL, set default format to json if we are running in a pipeline
     # and the right side of the pipe is the 'td' program
     {
-        last if (-t STDOUT) || $r->{format};
+        last if (is_interactive(*STDOUT)) || $r->{format};
         last unless eval { require Pipe::Find; 1 };
         my $pipeinfo = Pipe::Find::get_stdout_pipe_process();
         last unless $pipeinfo;

--- a/lib/Perinci/CmdLine/Base.pm
+++ b/lib/Perinci/CmdLine/Base.pm
@@ -28,7 +28,7 @@ sub __array_iter {
         if ($i < @$ary) {
             return $ary->[$i++];
         } else {
-            return undef;
+            return undef;  ## no critic
         }
     };
 }
@@ -295,7 +295,7 @@ _
             # we are not called from cmdline, bail (actually we might want to
             # return list of programs anyway, but we want to read the value of
             # bash_global_dir et al)
-            return undef unless $cmdline;
+            return undef unless $cmdline;  ## no critic
 
             # since this is common option, at this point we haven't parsed
             # argument or even read config file. let's parse argv first (argv
@@ -441,7 +441,7 @@ sub get_subcommand_data {
     my ($self, $name) = @_;
 
     my $scs = $self->subcommands;
-    return undef unless $scs;
+    return undef unless $scs;  ## no critic
 
     if (ref($scs) eq 'CODE') {
         return $scs->($self, name=>$name);
@@ -645,7 +645,7 @@ sub do_completion {
             }
 
             # otherwise let periscomp do its thing
-            return undef;
+            return undef;  ## no critic
         },
     );
 
@@ -1102,10 +1102,10 @@ sub __gen_iter {
             local $/ = \(64*1024) if $type eq 'buf';
 
             state $eof;
-            return undef if $eof;
+            return undef if $eof;  ## no critic
             my $l = <$fh>;
             unless (defined $l) {
-                $eof++; return undef;
+                $eof++; return undef;  ## no critic
             }
             chomp($l) if $chomp;
             $l;
@@ -1117,11 +1117,11 @@ sub __gen_iter {
         my $i = -1;
         return sub {
             state $eof;
-            return undef if $eof;
+            return undef if $eof;  ## no critic
             $i++;
             my $l = <$fh>;
             unless (defined $l) {
-                $eof++; return undef;
+                $eof++; return undef;  ## no critic
             }
             eval { $l = $json->decode($l) };
             if ($@) {

--- a/lib/Perinci/CmdLine/Base.pm
+++ b/lib/Perinci/CmdLine/Base.pm
@@ -709,7 +709,7 @@ sub _read_config {
     }
 }
 
-sub __min(@) {
+sub __min(@) {  ## no critic
     my $m = $_[0];
     for (@_) {
         $m = $_ if $_ < $m;

--- a/lib/Perinci/CmdLine/Lite.pm
+++ b/lib/Perinci/CmdLine/Lite.pm
@@ -7,6 +7,7 @@ use 5.010001;
 # use strict; # already enabled by Mo
 # use warnings; # already enabled by Mo
 use Log::ger;
+use IO::Interactive qw(is_interactive);
 
 use List::Util qw(first);
 use Mo qw(build default);
@@ -103,7 +104,7 @@ my $setup_progress;
 sub _setup_progress_output {
     my $self = shift;
 
-    return unless $ENV{PROGRESS} // (-t STDOUT);
+    return unless $ENV{PROGRESS} // (is_interactive(*STDOUT));
 
     require Progress::Any::Output;
     Progress::Any::Output->set("TermProgressBarColor");

--- a/lib/Perinci/CmdLine/Lite.pm
+++ b/lib/Perinci/CmdLine/Lite.pm
@@ -445,7 +445,7 @@ sub action_subcommands {
 }
 
 sub action_version {
-    no strict 'refs';
+    no strict 'refs';  ## no critic
 
     my ($self, $r) = @_;
 


### PR DESCRIPTION
`perlcritic` noticed (at the most gentle setting) various issues with the code.  Most of the issues were false alarms and hence I've disabled perlcritic warnings in these cases so that perlcritic is no longer so noisy and so that it can be used to pick up real issues in the future.  I've split this PR up into separate commits so that you can cherry pick them as you so wish.  If, after having reviewed the code, there's something that you'd like changed, please just let me know and I'll update as necessary and resubmit.