### PR TITLE
Move DATE and VERSION keywords after use statements

### DIFF
--- a/lib/Perinci/CmdLine/Base.pm
+++ b/lib/Perinci/CmdLine/Base.pm
@@ -1,12 +1,12 @@
 package Perinci::CmdLine::Base;
 
-# DATE
-# VERSION
-
 use 5.010001;
 use strict;
 use warnings;
 use Log::ger;
+
+# DATE
+# VERSION
 
 # this class can actually be a role instead of base class for pericmd &
 # pericmd-lite, but Mo is more lightweight than Role::Tiny (also R::T doesn't

--- a/lib/Perinci/CmdLine/Lite.pm
+++ b/lib/Perinci/CmdLine/Lite.pm
@@ -1,8 +1,5 @@
 package Perinci::CmdLine::Lite;
 
-# DATE
-# VERSION
-
 use 5.010001;
 # use strict; # already enabled by Mo
 # use warnings; # already enabled by Mo
@@ -12,6 +9,9 @@ use List::Util qw(first);
 use Mo qw(build default);
 #use Moo;
 extends 'Perinci::CmdLine::Base';
+
+# DATE
+# VERSION
 
 # when debugging, use this instead of the above because Mo doesn't give clear
 # error message if base class has errors.


### PR DESCRIPTION
The DATE and VERSION keywords get expanded by Dist::Zilla to `our`
variables after building the dist.  With these variables at the top of
the file, this made code appear before strictures were turned on and
hence caused the author critic tests to fail the strict and warnings
checks.  Moving the keywords after the list of dists used by the module
doesn't change the dist's behaviour but allows the author-critic tests
to pass as expected.

If you would like this PR to be changed in any way, please simply let me know and I'll update as appropriate and resubmit it.