### PR TITLE
Add initial GitHub Actions configuration

### DIFF
--- a/.github/workflows/perltest.yml
+++ b/.github/workflows/perltest.yml
@@ -1,0 +1,27 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest']
+        perl: [ 'latest' ]
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - run: cpanm --notest Dist::Zilla || { cat $HOME/.cpanm/build.log ; false ; }
+      - run: dzil authordeps --missing | cpanm --notest || { cat $HOME/.cpanm/build.log ; false ; }
+      - run: dzil listdeps --author --missing | cpanm --notest || { cat $HOME/.cpanm/build.log ; false ; }
+      - run: dzil test --author --release

--- a/dist.ini
+++ b/dist.ini
@@ -43,7 +43,7 @@ Fcntl=0
 File::Temp=0.2307
 File::Which=0
 Getopt::Long=2.50
-IO::Interactive=0
+; authordep IO::Interactive
 JSON::MaybeXS=0
 JSON::PP=0
 List::Util=1.45
@@ -64,6 +64,7 @@ Perinci::Sub::GetArgs::Argv=0.845
 ;Perinci::Sub::To::FishComplete=0
 ;!lint_prereqs assume-used "undetected, use via binmode()"
 PerlIO::locale=0
+; authordep Pod::Weaver::PluginBundle::Author::PERLANCAR
 Progress::Any::Output=0
 ;!lint_prereqs assume-used "via Progress::Any::Output->set"
 Progress::Any::Output::TermProgressBarColor=0.17


### PR DESCRIPTION
This PR replaces #4 because adding a Travis-CI configuration is no longer relevant.

In order to get automatic building and testing to work on GitHub Actions it was necessary to explicitly define two dependencies as being authordeps, namely `IO::Interactive` and `Pod::Weaver::PluginBundle::Author::PERLANCAR`.
It turns out that the `IO::Interactive` and `Pod::Weaver::PluginBundle::Author::PERLANCAR` packages aren't picked up by `dzil authordeps`, hence these packages aren't available when one wants to run `dzil listdeps` and thus the remainder of the dependencies installation fails.  By specifying them explicitly in `dist.ini` allows `dzil authordeps` to install them which then allows `dzil listdeps` to work correctly and hence all dependencies are able to be installed.

Note that this PR only adds build and test settings for Linux and MacOS; it wasn't possible to get the Windows configuration to install the authordeps for the distribution and hence a Windows CI/CD config isn't possible at this time.

For future reference, here are the issues I ran into:

  - the [`shogo82148/actions-setup-perl@v1`](https://github.com/shogo82148/actions-setup-perl) action, which provides
    "latest" versions of Perl for Linux, MacOS and Windows can't build a
    working `Dist::Zilla` for some reason.  I found that `Dist::Zilla`
    could be installed, however none of the `dzil` subcommands (other
    than `help`) worked, hence it wasn't possible to install upstream
    dependencies or run the test suite.
  - using the system Perl for the Windows platform allowed `Dist::Zilla`
    to install correctly, however the XS code required for the upstream
    dependency `B::Hooks::Parser` doesn't compile (at least not on the
    current system Perl provided by GitHub).  Consequently the
    authordeps installation fails and it's therefore not possible to
    build and test the distribution on Windows.  I found this rather odd
    because `B::Hooks::Parser` seems to build on Windows without a
    problem if one considers the its status on CPAN Testers.